### PR TITLE
Change read() to extract payload properly (fixes: #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-This library has been tested with Ratchet WAMP server. It can only send messages to the server, listening for replies is not implemented.
+This library has been tested with Ratchet WAMP server. It is based on the original WebSocketPhpClient and works with v2.0.0 of the GOS/Web-Socket-Bundle. It can only send messages to the server, listening for replies is not implemented.
 Supported functions:
  - prefix
  - call

--- a/src/Wamp/Client.php
+++ b/src/Wamp/Client.php
@@ -176,23 +176,19 @@ class Client implements LoggerAwareInterface
      */
     protected function read()
     {
-        // Ignore first byte
-        fread($this->socket, 1);
+        $stream = $this->socket;
 
-        // There is also masking bit, as MSB, bit it's 0
-        $payloadLength = \ord(fread($this->socket, 1));
+        $stream_meta_data =  stream_get_meta_data($stream);
 
-        switch ($payloadLength) {
-            case 126:
-                $payloadLength = unpack('n', fread($this->socket, 2));
-                $payloadLength = $payloadLength[1];
-                break;
-            case 127:
-                //$this->stdout('error', "Next 8 bytes are 64bit uint payload length, not yet implemented, since PHP can't handle 64bit longs!");
-                break;
-        }
+        $max_length = $stream_meta_data['unread_bytes'];
 
-        return fread($this->socket, $payloadLength);
+        $stream_data_string = stream_get_contents($stream, $max_length);
+
+        $startPos = strpos($stream_data_string, '[');
+
+        $endPos = strpos($stream_data_string, ']');
+
+        return substr($stream_data_string, $startPos, $endPos);
     }
 
     /**


### PR DESCRIPTION
Extracts payload of the initial WELCOME event in a more dynamic way. This change does not rely on a hard coded byte length and rather extracts the event based on the opening "[" and closing "]" brackets.
fixes: #2 