### PR TITLE
Fix reconnect on connection reset

### DIFF
--- a/src/Wamp/Client.php
+++ b/src/Wamp/Client.php
@@ -307,7 +307,7 @@ final class Client implements ClientInterface, LoggerAwareInterface
         );
 
         // Check if the connection was reset, if so try to reconnect
-        if (0 === @fwrite($this->socket, $encoded)) {
+        if (false === @fwrite($this->socket, $encoded)) {
             $this->connected = false;
             $this->connect($this->target);
 


### PR DESCRIPTION
The current check for detecting whether a reconnect is necessary does not work correctly. 

According to the [official documentation](https://www.php.net/manual/en/function.fwrite.php#refsect1-function.fwrite-returnvalues) `fwrite`() returns `false` when encountering an error.  In order to detect whether the connection was reset we should therefore check for `false` and not `0`.

I am aware that this package is deprecated, but it is still a dependency of [gos/web-socket-bundle](https://github.com/GeniusesOfSymfony/WebSocketBundle) 2.x and 3.x. Without this fix this package and therefore [gos/web-socket-bundle](https://github.com/GeniusesOfSymfony/WebSocketBundle)'s Pusher doesn't work reliably